### PR TITLE
Fixed bug failing to get a `str` representation of `Message` on `ipy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed bug failing to get a `str` representation of `Message` on `ipy`
+
 ### Removed
 
 

--- a/src/compas_eve/core.py
+++ b/src/compas_eve/core.py
@@ -50,8 +50,11 @@ class Message(UserDict):
 
     A message is fundamentally a dictionary and behaves as one."""
 
+    def __str__(self):
+        return str(self.data)
+
     def __getattr__(self, name):
-        return self.data[name]
+        return self.__dict__["data"][name]
 
     @classmethod
     def parse(cls, value):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -99,3 +99,8 @@ def test_message_type_parsing():
     assert received, "Message not received"
     assert result["value"].name == "Jazz"
     assert result["value"].hello_name == "Hello Jazz"
+
+
+def test_message_str():
+    msg = Message(a=3)
+    assert str(msg) == "{'a': 3}"


### PR DESCRIPTION
Tiny (and stupid) bug that caused any attempt to print a message instance to fail on ironpython because it tried to get the `__str__` representation and would end up in the `__getattr__` method.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
