### PR TITLE
Add publish_yak to invoke tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add missing `publish_yak` task for publishing packages to Rhino Package Manager.
+
 ### Changed
 
 ### Removed

--- a/tasks.py
+++ b/tasks.py
@@ -27,6 +27,7 @@ ns = Collection(
     build.clean,
     build.release,
     grasshopper.yakerize,
+    grasshopper.publish_yak,
     grasshopper.update_gh_header,
     generate_proto_classes,
 )


### PR DESCRIPTION
Publish workflow is failing because I forgot to add this here :P 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
